### PR TITLE
Don't do a blind read to ulCodePageRange

### DIFF
--- a/java/src/com/google/typography/font/tools/conversion/eot/EOTWriter.java
+++ b/java/src/com/google/typography/font/tools/conversion/eot/EOTWriter.java
@@ -166,8 +166,14 @@ public class EOTWriter {
 
   private int writeCodePages(int start, OS2Table os2Table, WritableFontData writableFontData) {
     int index = start;
-    index += writableFontData.writeULongLE(index, os2Table.ulCodePageRange1());
-    index += writableFontData.writeULongLE(index, os2Table.ulCodePageRange2());
+    if (os2Table.tableVersion() >= 1) {
+    	index += writableFontData.writeULongLE(index, os2Table.ulCodePageRange1());
+    	index += writableFontData.writeULongLE(index, os2Table.ulCodePageRange2());
+    }
+    else {
+    	index += writableFontData.writeULongLE(index, 0x00000001);
+    	index += writableFontData.writeULongLE(index, 0x00000000);
+    }
     return index - start;
   }
 


### PR DESCRIPTION
Don't do a blind read to ulCodePageRange if os/2 table version is 0.
Insert dummy data into ulCodePageRange1 & ulCodePageRange2
The eot spec requires the element to exist, and it will fail validation
in if it's missing.