### PR TITLE
SfntlyWrapper::SubsetFont takes TTC index

### DIFF
--- a/cpp/src/sample/chromium/font_subsetter.cc
+++ b/cpp/src/sample/chromium/font_subsetter.cc
@@ -37,3 +37,24 @@ int SfntlyWrapper::SubsetFont(const char* font_name,
 
   return subsetter.SubsetFont(glyph_ids, glyph_count, output_buffer);
 }
+
+int SfntlyWrapper::SubsetFont(int font_index,
+                              const unsigned char* original_font,
+                              size_t font_size,
+                              const unsigned int* glyph_ids,
+                              size_t glyph_count,
+                              unsigned char** output_buffer) {
+  if (output_buffer == NULL ||
+      original_font == NULL || font_size == 0 ||
+      glyph_ids == NULL || glyph_count == 0) {
+    return 0;
+  }
+
+  sfntly::SubsetterImpl subsetter;
+  if (!subsetter.LoadFont(font_index, original_font, font_size)) {
+    return -1;  // Load error or font not found.
+  }
+
+  return subsetter.SubsetFont(glyph_ids, glyph_count, output_buffer);
+}
+

--- a/cpp/src/sample/chromium/font_subsetter.h
+++ b/cpp/src/sample/chromium/font_subsetter.h
@@ -46,6 +46,30 @@ class SfntlyWrapper {
                         const unsigned int* glyph_ids,
                         size_t glyph_count,
                         unsigned char** output_buffer);
+
+
+  // Font subsetting API
+  //
+  // Input TTF/TTC/OTF fonts, specify the glyph IDs to subset, and the subset
+  // font is returned in |output_buffer| (caller to delete[]).  Return value is
+  // the length of output_buffer allocated.
+  //
+  // If subsetting fails, a negative value is returned.  If none of the glyph
+  // IDs specified is found, the function will return 0.
+  //
+  // |font_name|      Font index, ignored for non-TTC files, 0-indexed.
+  // |original_font|  Original font file contents.
+  // |font_size|      Size of |original_font| in bytes.
+  // |glyph_ids|      Glyph IDs to subset.  If the specified glyph ID is not
+  //                  found in the font file, it will be ignored silently.
+  // |glyph_count|    Number of glyph IDs in |glyph_ids|
+  // |output_buffer|  Generated subset font.  Caller to delete[].
+  static int SubsetFont(int font_index,
+                        const unsigned char* original_font,
+                        size_t font_size,
+                        const unsigned int* glyph_ids,
+                        size_t glyph_count,
+                        unsigned char** output_buffer);
 };
 
 #endif  // SFNTLY_CPP_SRC_TEST_FONT_SUBSETTER_H_

--- a/cpp/src/sample/chromium/subsetter_impl.cc
+++ b/cpp/src/sample/chromium/subsetter_impl.cc
@@ -616,6 +616,24 @@ SubsetterImpl::SubsetterImpl() {
 SubsetterImpl::~SubsetterImpl() {
 }
 
+bool SubsetterImpl::LoadFont(int font_index,
+                             const unsigned char* original_font,
+                             size_t font_size) {
+  MemoryInputStream mis;
+  mis.Attach(original_font, font_size);
+  if (factory_ == NULL) {
+    factory_.Attach(FontFactory::GetInstance());
+  }
+
+  FontArray font_array;
+  factory_->LoadFonts(&mis, &font_array);
+  if (font_index < 0 || (size_t)font_index >= font_array.size()) {
+    return false;
+  }
+  font_ = font_array[font_index].p_;
+  return font_ != NULL;
+}
+
 bool SubsetterImpl::LoadFont(const char* font_name,
                              const unsigned char* original_font,
                              size_t font_size) {

--- a/cpp/src/sample/chromium/subsetter_impl.h
+++ b/cpp/src/sample/chromium/subsetter_impl.h
@@ -57,6 +57,9 @@ class SubsetterImpl {
   bool LoadFont(const char* font_name,
                 const unsigned char* original_font,
                 size_t font_size);
+  bool LoadFont(int font_index,
+                const unsigned char* original_font,
+                size_t font_size);
   int SubsetFont(const unsigned int* glyph_ids,
                  size_t glyph_count,
                  unsigned char** output_buffer);


### PR DESCRIPTION
Needed by SkPDF.

We get a TTC stream and index from `SkTypeface::openStream()`.  It's easier to use the index than the font name, which may not be available or even unique.