### PR TITLE
Fix invalid cast found by Control Flow Integrity.

### DIFF
--- a/cpp/src/sfntly/port/refcount.h
+++ b/cpp/src/sfntly/port/refcount.h
@@ -99,22 +99,18 @@
 
 namespace sfntly {
 
+template <typename T>
+class Ptr;
+
 class RefCount {
  public:
   // Make gcc -Wnon-virtual-dtor happy.
   virtual ~RefCount() {}
 
-  virtual size_t AddRef() const = 0;
-  virtual size_t Release() const = 0;
-};
-
-template <typename T>
-class NoAddRefRelease : public T {
- public:
-  NoAddRefRelease();
-  ~NoAddRefRelease();
-
  private:
+  template <typename T>
+  friend class Ptr;
+
   virtual size_t AddRef() const = 0;
   virtual size_t Release() const = 0;
 };
@@ -142,6 +138,7 @@ class RefCounted : virtual public RefCount {
     return *this;
   }
 
+ private:
   virtual size_t AddRef() const {
     size_t new_count = AtomicIncrement(&ref_count_);
     DEBUG_OUTPUT("A ");
@@ -224,8 +221,8 @@ class Ptr {
     return *p_;  // It can throw!
   }
 
-  NoAddRefRelease<T>* operator->() const {
-    return (NoAddRefRelease<T>*)p_;  // It can throw!
+  T* operator->() const {
+    return p_;  // It can throw!
   }
 
   bool operator!() const {


### PR DESCRIPTION
Instead of casting RefCounted objects to type NoAddRefRelease, make
AddRef() and Release() private methods that are only accessible to a
limited number of friends.
Fixes https://crbug.com/517959