### PR TITLE
Cleanup random bits of code.

### DIFF
--- a/cpp/src/sample/chromium/subsetter_impl.cc
+++ b/cpp/src/sample/chromium/subsetter_impl.cc
@@ -16,11 +16,11 @@
 
 #include "subsetter_impl.h"
 
-#include <limits.h>
 #include <string.h>
 
 #include <algorithm>
 #include <iterator>
+#include <limits>
 #include <map>
 #include <set>
 
@@ -272,7 +272,7 @@ bool SetupGlyfBuilders(Font::Builder* font_builder,
       loca_list[j] = last_offset;
     }
 
-    if (last_offset > INT_MAX - length)
+    if (last_offset > std::numeric_limits<int32_t>::max() - length)
       return false;
 
     last_offset += length;
@@ -289,14 +289,15 @@ bool SetupGlyfBuilders(Font::Builder* font_builder,
 
 bool HasOverlap(int32_t range_begin, int32_t range_end,
                 const IntegerSet& glyph_ids) {
-  if (range_begin == range_end) {
+  if (range_begin == range_end)
     return glyph_ids.find(range_begin) != glyph_ids.end();
-  } else if (range_end > range_begin) {
-    IntegerSet::const_iterator left = glyph_ids.lower_bound(range_begin);
-    IntegerSet::const_iterator right = glyph_ids.lower_bound(range_end);
-    return right != left;
-  }
-  return false;
+
+  if (range_begin >= range_end)
+    return false;
+
+  IntegerSet::const_iterator left = glyph_ids.lower_bound(range_begin);
+  IntegerSet::const_iterator right = glyph_ids.lower_bound(range_end);
+  return left != right;
 }
 
 // Initialize builder, returns false if glyph_id subset is not covered.
@@ -654,11 +655,7 @@ bool SubsetterImpl::LoadFont(const char* font_name,
   FontArray font_array;
   factory_->LoadFonts(&mis, &font_array);
   font_ = FindFont(font_name, font_array);
-  if (font_ == NULL) {
-    return false;
-  }
-
-  return true;
+  return font_ != NULL;
 }
 
 int SubsetterImpl::SubsetFont(const unsigned int* glyph_ids,
@@ -692,12 +689,14 @@ int SubsetterImpl::SubsetFont(const unsigned int* glyph_ids,
 
   MemoryOutputStream output_stream;
   factory_->SerializeFont(new_font, &output_stream);
-  int length = static_cast<int>(output_stream.Size());
-  if (length > 0) {
-    *output_buffer = new unsigned char[length];
-    memcpy(*output_buffer, output_stream.Get(), length);
+  size_t length = output_stream.Size();
+  if (length == 0 ||
+      length > static_cast<size_t>(std::numeric_limits<int>::max())) {
+    return 0;
   }
 
+  *output_buffer = new unsigned char[length];
+  memcpy(*output_buffer, output_stream.Get(), length);
   return length;
 }
 
@@ -759,6 +758,8 @@ Font* SubsetterImpl::Subset(const IntegerSet& glyph_ids, GlyphTable* glyf,
     Tag::cmap,  // Keep here for future tagged PDF development.
     Tag::name,  // Keep here due to legal concerns: copyright info inside.
   };
+  const size_t kTablesInSubSetSize =
+      sizeof(TABLES_IN_SUBSET) / sizeof(TABLES_IN_SUBSET[0]);
 
   // Setup font builders we need.
   FontBuilderPtr font_builder;
@@ -786,9 +787,8 @@ Font* SubsetterImpl::Subset(const IntegerSet& glyph_ids, GlyphTable* glyf,
   }
 
   IntegerSet allowed_tags;
-  for (size_t i = 0; i < sizeof(TABLES_IN_SUBSET) / sizeof(int32_t); ++i) {
+  for (size_t i = 0; i < kTablesInSubSetSize; ++i)
     allowed_tags.insert(TABLES_IN_SUBSET[i]);
-  }
 
   IntegerSet result;
   std::set_difference(allowed_tags.begin(), allowed_tags.end(),
@@ -797,12 +797,12 @@ Font* SubsetterImpl::Subset(const IntegerSet& glyph_ids, GlyphTable* glyf,
   allowed_tags = result;
 
   // Setup remaining builders.
-  for (IntegerSet::iterator i = allowed_tags.begin(), e = allowed_tags.end();
-                            i != e; ++i) {
-    Table* table = font_->GetTable(*i);
-    if (table) {
-      font_builder->NewTableBuilder(*i, table->ReadFontData());
-    }
+  for (IntegerSet::const_iterator it = allowed_tags.begin();
+       it != allowed_tags.end(); ++it) {
+    int32_t tag = *it;
+    Table* table = font_->GetTable(tag);
+    if (table)
+      font_builder->NewTableBuilder(tag, table->ReadFontData());
   }
 
   return font_builder->Build();

--- a/cpp/src/sfntly/font_factory.cc
+++ b/cpp/src/sfntly/font_factory.cc
@@ -96,12 +96,8 @@ void FontFactory::LoadFontsForBuilding(std::vector<uint8_t>* b,
 }
 
 void FontFactory::SerializeFont(Font* font, OutputStream* os) {
-  font->Serialize(os, &table_ordering_);
-}
-
-void FontFactory::SetSerializationTableOrdering(
-    const std::vector<int32_t>& table_ordering) {
-  table_ordering_ = table_ordering;
+  std::vector<int32_t> table_ordering;
+  font->Serialize(os, &table_ordering);
 }
 
 CALLER_ATTACH Font::Builder* FontFactory::NewFontBuilder() {

--- a/cpp/src/sfntly/font_factory.h
+++ b/cpp/src/sfntly/font_factory.h
@@ -81,12 +81,6 @@ class FontFactory : public RefCounted<FontFactory> {
   //       Byte buffer it is.
   void SerializeFont(Font* font, OutputStream* os);
 
-  // Set the table ordering to be used in serializing a font. The table ordering
-  // is an ordered list of table ids and tables will be serialized in the order
-  // given. Any tables whose id is not listed in the ordering will be placed in
-  // an unspecified order following those listed.
-  void SetSerializationTableOrdering(const std::vector<int32_t>& table_ordering);
-
   // Get an empty font builder for creating a new font from scratch.
   CALLER_ATTACH Font::Builder* NewFontBuilder();
 
@@ -131,7 +125,6 @@ class FontFactory : public RefCounted<FontFactory> {
   static bool IsCollection(ReadableFontData* wfd);
 
   bool fingerprint_;
-  std::vector<int32_t> table_ordering_;
 };
 typedef Ptr<FontFactory> FontFactoryPtr;
 

--- a/cpp/src/sfntly/table/header.h
+++ b/cpp/src/sfntly/table/header.h
@@ -34,51 +34,51 @@ class Header : public RefCounted<Header> {
   virtual ~Header();
 
   // Get the table tag.
-  int32_t tag() { return tag_; }
+  int32_t tag() const { return tag_; }
 
   // Get the table offset. The offset is from the start of the font file.  This
   // offset value is what was read from the font file during construction of the
   // font. It may not be meaningful if the font was maninpulated through the
   // builders.
-  int32_t offset() { return offset_; }
+  int32_t offset() const { return offset_; }
 
   // Is the offset in the header valid. The offset will not be valid if the
   // table was constructed during building and has no physical location in a
   // font file.
-  bool offset_valid() { return offset_valid_; }
+  bool offset_valid() const { return offset_valid_; }
 
   // Get the length of the table as recorded in the table record header.  During
   // building the header length will reflect the length that was initially read
   // from the font file. This may not be consistent with the current state of
   // the data.
-  int32_t length() { return length_; }
+  int32_t length() const { return length_; }
 
   // Is the length in the header valid. The length will not be valid if the
   // table was constructed during building and has no physical location in a
   // font file until the table is built from the builder.
-  bool length_valid() { return length_valid_; }
+  bool length_valid() const { return length_valid_; }
 
   // Get the checksum for the table as recorded in the table record header.
-  int64_t checksum() { return checksum_; }
+  int64_t checksum() const { return checksum_; }
 
   // Is the checksum valid. The checksum will not be valid if the table was
   // constructed during building and has no physical location in a font file.
   // Note that this does *NOT* check the validity of the checksum against
   // the calculated checksum for the table data.
-  bool checksum_valid() { return checksum_valid_; }
+  bool checksum_valid() const { return checksum_valid_; }
 
   // UNIMPLEMENTED: boolean equals(Object obj)
   //                int hashCode()
   //                string toString()
 
  private:
-  int32_t tag_;
-  int32_t offset_;
-  bool offset_valid_;
-  int32_t length_;
-  bool length_valid_;
-  int64_t checksum_;
-  bool checksum_valid_;
+  const int32_t tag_;
+  const int32_t offset_;
+  const bool offset_valid_;
+  const int32_t length_;
+  const bool length_valid_;
+  const int64_t checksum_;
+  const bool checksum_valid_;
 
   friend class HeaderComparatorByOffset;
   friend class HeaderComparatorByTag;


### PR DESCRIPTION
- Simplify iterator usage.
- Use std::numeric_limits in a couple places.
- Remove unused FontFactory::SetSerializationTableOrdering().
- Mark more variables/methods as const.

No behavior changes.