### PR TITLE
Check read value in CompositeGlyph::Initialize()

### DIFF
--- a/cpp/src/sfntly/table/truetype/glyph_table.cc
+++ b/cpp/src/sfntly/table/truetype/glyph_table.cc
@@ -522,6 +522,8 @@ GlyphTable::CompositeGlyph::~CompositeGlyph() {
 }
 
 int32_t GlyphTable::CompositeGlyph::Flags(int32_t contour) {
+  if (contour < 0 || static_cast<size_t>(contour) >= contour_index_.size())
+    return ReadableFontData::kInvalidUnsigned;
   return data_->ReadUShort(contour_index_[contour]);
 }
 
@@ -530,6 +532,8 @@ int32_t GlyphTable::CompositeGlyph::NumGlyphs() {
 }
 
 int32_t GlyphTable::CompositeGlyph::GlyphIndex(int32_t contour) {
+  if (contour < 0 || static_cast<size_t>(contour) >= contour_index_.size())
+    return ReadableFontData::kInvalidUnsigned;
   return data_->ReadUShort(DataSize::kUSHORT + contour_index_[contour]);
 }
 

--- a/cpp/src/sfntly/table/truetype/glyph_table.cc
+++ b/cpp/src/sfntly/table/truetype/glyph_table.cc
@@ -626,6 +626,9 @@ void GlyphTable::CompositeGlyph::Initialize() {
   while ((flags & kFLAG_MORE_COMPONENTS) == kFLAG_MORE_COMPONENTS) {
     contour_index_.push_back(index);
     flags = data_->ReadUShort(index);
+    if (flags == ReadableFontData::kInvalidUnsigned)
+      break;
+
     index += 2 * DataSize::kUSHORT;  // flags and glyphIndex
     if ((flags & kFLAG_ARG_1_AND_2_ARE_WORDS) == kFLAG_ARG_1_AND_2_ARE_WORDS) {
       index += 2 * DataSize::kSHORT;

--- a/cpp/src/sfntly/table/truetype/glyph_table.h
+++ b/cpp/src/sfntly/table/truetype/glyph_table.h
@@ -199,11 +199,6 @@ class GlyphTable : public SubTableContainerTable,
     virtual CALLER_ATTACH ReadableFontData* Instructions();
     virtual void Initialize();
 
-    int32_t NumberOfPoints(int32_t contour);
-    int32_t XCoordinate(int32_t contour, int32_t point);
-    int32_t YCoordinate(int32_t contour, int32_t point);
-    bool OnCurve(int32_t contour, int32_t point);
-
    private:
     void ParseData(bool fill_arrays);
     int32_t FlagAsInt(int32_t index);
@@ -272,10 +267,6 @@ class GlyphTable : public SubTableContainerTable,
     int32_t Flags(int32_t contour);
     int32_t NumGlyphs();
     int32_t GlyphIndex(int32_t contour);
-    int32_t Argument1(int32_t contour);
-    int32_t Argument2(int32_t contour);
-    int32_t TransformationSize(int32_t contour);
-    void Transformation(int32_t contour, std::vector<uint8_t>* transformation);
     virtual int32_t InstructionSize();
     virtual CALLER_ATTACH ReadableFontData* Instructions();
 


### PR DESCRIPTION
During initialization, the loop that does the reads can go out of bounds. The return value is -1 but there is no check for that. Thus the loop keeps going for much longer than it has to.

While we are here, also sanitize the usage of the contour_index_ variable as some of that looks suspicious.