### PR TITLE
Fix endless loop in FontMath.log2.

### DIFF
--- a/java/src/com/google/typography/font/sfntly/math/FontMath.java
+++ b/java/src/com/google/typography/font/sfntly/math/FontMath.java
@@ -27,13 +27,7 @@ public final class FontMath {
   }
 
   public static int log2(int a) {
-    int r = 0; // r will be lg(a)
-
-    while (a != 0) {
-      a >>= 1;
-      r++;
-    }
-    return r - 1;
+    return 31 - Integer.numberOfLeadingZeros(a);
   }
 
   /**

--- a/java/test/com/google/typography/font/sfntly/math/FontMathTest.java
+++ b/java/test/com/google/typography/font/sfntly/math/FontMathTest.java
@@ -1,0 +1,18 @@
+package com.google.typography.font.sfntly.math;
+
+import junit.framework.TestCase;
+
+public class FontMathTest extends TestCase {
+
+  public void testLog2() {
+    assertEquals(-1, FontMath.log2(0));
+    assertEquals(0, FontMath.log2(1));
+    assertEquals(1, FontMath.log2(2));
+    assertEquals(1, FontMath.log2(3));
+    assertEquals(2, FontMath.log2(4));
+    assertEquals(4, FontMath.log2(31));
+    assertEquals(5, FontMath.log2(32));
+    assertEquals(31, FontMath.log2(-1));
+  }
+
+}


### PR DESCRIPTION
For negative values the >> operator led to an endless loop.

Using the math provided by the Java standard library is safer.